### PR TITLE
Fix cart rendering by storing multiple items as an array

### DIFF
--- a/src/js/product.js
+++ b/src/js/product.js
@@ -1,9 +1,4 @@
 
-//BUG ISSUE: CartItem was not an array when calling CartItems.Map in cart.js
-//when I tried to renderCartContents() It sets the localStorage["so-cart"] 
-// to a single object, not an array
-//we also needed to add the getLocalStorage import function to pull the data
-
 //added the getLocalStorage function from  
 import { getLocalStorage, setLocalStorage } from "./utils.mjs";
 import ProductData from "./ProductData.mjs";

--- a/src/js/product.js
+++ b/src/js/product.js
@@ -1,10 +1,28 @@
-import { setLocalStorage } from "./utils.mjs";
+
+//BUG ISSUE: CartItem was not an array when calling CartItems.Map in cart.js
+//when I tried to renderCartContents() It sets the localStorage["so-cart"] 
+// to a single object, not an array
+//we also needed to add the getLocalStorage import function to pull the data
+
+//added the getLocalStorage function from  
+import { getLocalStorage, setLocalStorage } from "./utils.mjs";
 import ProductData from "./ProductData.mjs";
 
 const dataSource = new ProductData("tents");
-
 function addProductToCart(product) {
-  setLocalStorage("so-cart", product);
+  //Get the existing items in the cart or start with an empty array
+  let cartItems = getLocalStorage("so-cart")
+
+  //Checking if cartItems is an arry. If not, force it into an array.
+  if (!Array.isArray(cartItems)) {
+    cartItems = [cartItems];
+  }
+
+  //add this new product to the array
+  cartItems.push(product);
+  //save updated array back to localStorage
+  setLocalStorage("so-cart", cartItems);
+
 }
 // add to cart button event handler
 async function addToCartHandler(e) {


### PR DESCRIPTION
Previously, `so-cart` in localStorage was storing only a single object, 
causing `cartItems.map(...)` to fail because `cartItems` was not an array.

Changes:
- Updated `addProductToCart` to push new items into an array instead of overwriting.
- Imported and used `getLocalStorage` to properly retrieve the cart data.
- Ensured `cartItems.map(...)` is only called once we confirm `cartItems` is an array.

