### PR TITLE
Fix: Corrected Input Types for Checkout Form

### DIFF
--- a/src/checkout/index.html
+++ b/src/checkout/index.html
@@ -31,9 +31,9 @@
       </fieldset>
       <fieldset>
         <legend>Payment</legend>
-        <label>Card Number<input type="number" name="cardNumber" id="cardNumber" required /></label>
-        <label>Expiration<input type="number" name="expiration" id="expiration" required /></label>
-        <label>Security COde<input type="text" name="code" id="code" required /></label>
+        <label>Card Number<input type="text" name="cardNumber" id="cardNumber" required /></label>
+        <label>Expiration<input type="text" name="expiration" id="expiration" required /></label>
+        <label>Security Code<input type="text" name="code" id="code" required /></label>
       </fieldset>
       <fieldset class="checkout-summary">
         <legend>Order Summary</legend>


### PR DESCRIPTION
**Issue:**
The checkout form was sending number inputs for credit card number, expiration date, and security code, causing a 400 Bad Request error from the server.

**Fix:**
Changed input types from number to string(text) for:
- Credit card number
- Expiration date
- CVV (security code)
 